### PR TITLE
Bucket mounting

### DIFF
--- a/hpc_provisioner/pyproject.toml
+++ b/hpc_provisioner/pyproject.toml
@@ -30,7 +30,7 @@ relative_to = "pyproject.toml"
 root = ".."
 
 [project.optional-dependencies]
-test = ["pytest", "pytest-cov"]
+test = ["pytest", "pytest-cov", "pytest-env"]
 
 [project.scripts]
 hpc-provisioner = "hpc_provisioner.commands:hpc_provisioner"
@@ -54,3 +54,9 @@ select = ["E",  # pycodestyle
 
 [tool.pytest.ini_options]
 addopts = ["--import-mode=importlib", "-vv", "--disable-warnings", "--cov=hpc_provisioner/src", "--cov-report", "term", "--cov-report", "xml:coverage.xml", "--junitxml", "unittests.xml"]
+
+[tool.pytest_env]
+SBO_NEXUSDATA_BUCKET = "s3://sbonexusdata-test"
+CONTAINERS_BUCKET = "s3://sboinfrastructureassets-test/containers"
+SCRATCH_BUCKET = "s3://scratch-test"
+EFA_SG_ID = "sg-123456789"

--- a/hpc_provisioner/src/hpc_provisioner/aws_queries.py
+++ b/hpc_provisioner/src/hpc_provisioner/aws_queries.py
@@ -290,3 +290,10 @@ def list_existing_stacks(cf_client):
     ]
 
     return existing_stack_names
+
+
+def create_bucket_path(s3_client, bucket: str, path: str) -> None:
+    bucket = bucket.replace("s3://", "")
+    if not path.endswith("/"):
+        path += "/"
+    s3_client.put_object(bucket, path)

--- a/hpc_provisioner/src/hpc_provisioner/aws_queries.py
+++ b/hpc_provisioner/src/hpc_provisioner/aws_queries.py
@@ -290,10 +290,3 @@ def list_existing_stacks(cf_client):
     ]
 
     return existing_stack_names
-
-
-def create_bucket_path(s3_client, bucket: str, path: str) -> None:
-    bucket = bucket.replace("s3://", "")
-    if not path.endswith("/"):
-        path += "/"
-    s3_client.put_object(bucket, path)

--- a/hpc_provisioner/src/hpc_provisioner/config-dev/_lustre_storage.tpl.yaml
+++ b/hpc_provisioner/src/hpc_provisioner/config-dev/_lustre_storage.tpl.yaml
@@ -9,8 +9,19 @@ FsxLustreSettings:
   DataCompressionType: LZ4  # Data compression for higher-throughput between OSSs <-> OSTs
   DeletionPolicy: Delete
   DataRepositoryAssociations:
+    - Name: Nexus-DRA
+      BatchImportMetaDataOnCreate: true
+      DataRepositoryPath: !config sbonexusdata_bucket
+      FileSystemPath: /project
+      AutoImportPolicy: [NEW, CHANGED, DELETED]
     - Name: Containers-DRA
       BatchImportMetaDataOnCreate: true
       DataRepositoryPath: !config containers_bucket
       FileSystemPath: /containers
+      AutoImportPolicy: [NEW, CHANGED, DELETED]
+    - Name: Scratch-DRA
+      BatchImportMetaDataOnCreate: true
+      DataRepositoryPath: !config scratch_bucket
+      FileSystemPath: /scratch
+      AutoExportPolicy: [NEW, CHANGED, DELETED]
       AutoImportPolicy: [NEW, CHANGED, DELETED]

--- a/hpc_provisioner/src/hpc_provisioner/config-dev/_lustre_storage.tpl.yaml
+++ b/hpc_provisioner/src/hpc_provisioner/config-dev/_lustre_storage.tpl.yaml
@@ -19,7 +19,6 @@ FsxLustreSettings:
       BatchImportMetaDataOnCreate: true
       DataRepositoryPath: !config containers_bucket
       FileSystemPath: /containers
-      AutoExportPolicy: [NEW]
       AutoImportPolicy: [NEW, CHANGED, DELETED]
     - Name: Scratch-DRA
       BatchImportMetaDataOnCreate: true

--- a/hpc_provisioner/src/hpc_provisioner/config-dev/_lustre_storage.tpl.yaml
+++ b/hpc_provisioner/src/hpc_provisioner/config-dev/_lustre_storage.tpl.yaml
@@ -9,20 +9,8 @@ FsxLustreSettings:
   DataCompressionType: LZ4  # Data compression for higher-throughput between OSSs <-> OSTs
   DeletionPolicy: Delete
   DataRepositoryAssociations:
-    - Name: Nexus-DRA
-      BatchImportMetaDataOnCreate: true
-      DataRepositoryPath: !config sbonexusdata_bucket
-      FileSystemPath: /project
-      AutoExportPolicy: [NEW]
-      AutoImportPolicy: [NEW, CHANGED, DELETED]
     - Name: Containers-DRA
       BatchImportMetaDataOnCreate: true
       DataRepositoryPath: !config containers_bucket
       FileSystemPath: /containers
-      AutoImportPolicy: [NEW, CHANGED, DELETED]
-    - Name: Scratch-DRA
-      BatchImportMetaDataOnCreate: true
-      DataRepositoryPath: !config scratch_bucket
-      FileSystemPath: /scratch
-      AutoExportPolicy: [NEW, CHANGED, DELETED]
       AutoImportPolicy: [NEW, CHANGED, DELETED]

--- a/hpc_provisioner/src/hpc_provisioner/config-dev/_slurm_queues.tpl.yaml
+++ b/hpc_provisioner/src/hpc_provisioner/config-dev/_slurm_queues.tpl.yaml
@@ -42,13 +42,6 @@
       MaxCount: 20  # least number of nodes needed to simulate the full O1 circuit x2
       Efa:  # low-latency, high BW network
         Enabled: true  # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html#efa-start-security
-    # - Name: nvme
-    #   Instances:
-    #   - InstanceType: c5d.24xlarge  # provides additionally nvme support
-    #   MinCount: 0
-    #   MaxCount: 2  # upper limit for functionalizer use-case defined in cost estimation sheet
-    #   Efa:
-    #     Enabled: false
   Networking:
     PlacementGroup:  # try to place nodes close to each other
       Enabled: true
@@ -112,30 +105,3 @@
   #         Args:
   #           - /sbo/home/resources/users.json
   #       - Script: s3://sboinfrastructureassets-sandbox/scripts/setup_environment_compute.sh
-
-# ==========================================
-# prod-hpc16x queue, for HPC jobs (64 vCPUs)
-# ==========================================
-- Name: prod-hpc16x
-  AllocationStrategy: lowest-price
-  ComputeResources:
-    - Name: cpu-hpc7g
-      Instances:
-        - InstanceType: hpc7g.16xlarge  # HPC compute nodes
-      MinCount: 0
-      MaxCount: 20  # temporary, may need to be increased to simulate larger circuits
-      Efa:  # low-latency, high BW network
-        Enabled: true  # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html#efa-start-security
-  Networking:
-    PlacementGroup:  # try to place nodes close to each other
-      Enabled: true
-    SubnetIds: [!config base_subnet_id]
-    SecurityGroups:
-      - !config base_security_group_id
-      - !config efa_security_group_id  # Efa
-  CustomSlurmSettings:
-    MaxNodes: 20
-    MaxTime: 720
-  Iam:
-    S3Access:
-      - BucketName: sboinfrastructureassets-sandbox

--- a/hpc_provisioner/src/hpc_provisioner/config/_lustre_storage.tpl.yaml
+++ b/hpc_provisioner/src/hpc_provisioner/config/_lustre_storage.tpl.yaml
@@ -13,13 +13,11 @@ FsxLustreSettings:
       BatchImportMetaDataOnCreate: true
       DataRepositoryPath: !config sbonexusdata_bucket
       FileSystemPath: /project
-      AutoExportPolicy: [NEW]
       AutoImportPolicy: [NEW, CHANGED, DELETED]
     - Name: Containers-DRA
       BatchImportMetaDataOnCreate: true
       DataRepositoryPath: !config containers_bucket
       FileSystemPath: /containers
-      AutoExportPolicy: [NEW]
       AutoImportPolicy: [NEW, CHANGED, DELETED]
     - Name: Scratch-DRA
       BatchImportMetaDataOnCreate: true

--- a/hpc_provisioner/src/hpc_provisioner/config/_slurm_queues.tpl.yaml
+++ b/hpc_provisioner/src/hpc_provisioner/config/_slurm_queues.tpl.yaml
@@ -42,13 +42,6 @@
       MaxCount: 20  # least number of nodes needed to simulate the full O1 circuit x2
       Efa:  # low-latency, high BW network
         Enabled: true  # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html#efa-start-security
-    # - Name: nvme
-    #   Instances:
-    #   - InstanceType: c5d.24xlarge  # provides additionally nvme support
-    #   MinCount: 0
-    #   MaxCount: 2  # upper limit for functionalizer use-case defined in cost estimation sheet
-    #   Efa:
-    #     Enabled: false
   Networking:
     PlacementGroup:  # try to place nodes close to each other
       Enabled: true
@@ -112,30 +105,3 @@
   #         Args:
   #           - /sbo/home/resources/users.json
   #       - Script: s3://sboinfrastructureassets-sandbox/scripts/setup_environment_compute.sh
-
-# ==========================================
-# prod-hpc16x queue, for HPC jobs (64 vCPUs)
-# ==========================================
-- Name: prod-hpc16x
-  AllocationStrategy: lowest-price
-  ComputeResources:
-    - Name: cpu-hpc7g
-      Instances:
-        - InstanceType: hpc7g.16xlarge  # HPC compute nodes
-      MinCount: 0
-      MaxCount: 20  # temporary, may need to be increased to simulate larger circuits
-      Efa:  # low-latency, high BW network
-        Enabled: true  # https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start.html#efa-start-security
-  Networking:
-    PlacementGroup:  # try to place nodes close to each other
-      Enabled: true
-    SubnetIds: [!config base_subnet_id]
-    SecurityGroups:
-      - !config base_security_group_id
-      - !config efa_security_group_id  # Efa
-  CustomSlurmSettings:
-    MaxNodes: 20
-    MaxTime: 720
-  Iam:
-    S3Access:
-      - BucketName: sboinfrastructureassets-sandbox

--- a/hpc_provisioner/src/hpc_provisioner/constants.py
+++ b/hpc_provisioner/src/hpc_provisioner/constants.py
@@ -14,6 +14,7 @@ DEFAULTS = {
     "fs_type": "efs",
     "project_id": "-",
     "dev": "false",
+    "benchmark": "false",
     "include_lustre": "true",
 }
 

--- a/hpc_provisioner/src/hpc_provisioner/handlers.py
+++ b/hpc_provisioner/src/hpc_provisioner/handlers.py
@@ -211,7 +211,7 @@ def _get_vlab_query_params(event):
                 else:
                     params[param] = query_string_parameters.pop(param, None)
 
-    for bool_param in ["benchmark", "dev"]:
+    for bool_param in ["benchmark", "dev", "include_lustre"]:
         if isinstance(params[bool_param], str):
             params[bool_param] = params[bool_param].lower() == "true"
         elif not isinstance(params[bool_param], bool):

--- a/hpc_provisioner/src/hpc_provisioner/handlers.py
+++ b/hpc_provisioner/src/hpc_provisioner/handlers.py
@@ -183,6 +183,7 @@ def _get_vlab_query_params(event):
     logger.debug(f"Getting query params from event {event}")
 
     params = {
+        "benchmark": event.get("benchmark"),
         "dev": event.get("dev"),
         "include_lustre": event.get("include_lustre"),
         "tier": event.get("tier"),
@@ -205,15 +206,16 @@ def _get_vlab_query_params(event):
                     f"Parameter {param} not defined yet - "
                     "checking queryStringParameters {queryStringParameters}"
                 )
-                if param in ["dev"]:
+                if param in ["benchmark", "dev"]:
                     params[param] = query_string_parameters.pop(param, False)
                 else:
                     params[param] = query_string_parameters.pop(param, None)
 
-    if isinstance(params["dev"], str):
-        params["dev"] = params["dev"].lower() == "true"
-    elif not isinstance(params["dev"], bool):
-        params["dev"] = False
+    for bool_param in ["benchmark", "dev"]:
+        if isinstance(params[bool_param], str):
+            params[bool_param] = params[bool_param].lower() == "true"
+        elif not isinstance(params[bool_param], bool):
+            params[bool_param] = False
 
     if params["vlab_id"] is None:
         raise InvalidRequest("missing required 'vlab_id' query param")

--- a/hpc_provisioner/src/hpc_provisioner/handlers.py
+++ b/hpc_provisioner/src/hpc_provisioner/handlers.py
@@ -211,11 +211,17 @@ def _get_vlab_query_params(event):
                 else:
                     params[param] = query_string_parameters.pop(param, None)
 
-    for bool_param in ["benchmark", "dev", "include_lustre"]:
-        if isinstance(params[bool_param], str):
-            params[bool_param] = params[bool_param].lower() == "true"
-        elif not isinstance(params[bool_param], bool):
-            params[bool_param] = False
+    for default_false_bool_param in ["benchmark", "dev"]:
+        if isinstance(params[default_false_bool_param], str):
+            params[default_false_bool_param] = params[default_false_bool_param].lower() == "true"
+        elif not isinstance(params[default_false_bool_param], bool):
+            params[default_false_bool_param] = False
+
+    for default_true_bool_param in ["include_lustre"]:
+        if isinstance(params[default_true_bool_param], str):
+            params[default_true_bool_param] = params[default_true_bool_param].lower() == "true"
+        elif not isinstance(params[default_true_bool_param], bool):
+            params[default_true_bool_param] = True
 
     if params["vlab_id"] is None:
         raise InvalidRequest("missing required 'vlab_id' query param")

--- a/hpc_provisioner/src/hpc_provisioner/pcluster_manager.py
+++ b/hpc_provisioner/src/hpc_provisioner/pcluster_manager.py
@@ -62,7 +62,6 @@ def populate_config(
     vlab_id: str,
     project_id: str,
     cluster_users: Optional[str] = None,
-    dev: Optional[bool] = False,
     benchmark: Optional[bool] = False,
 ) -> None:
     """
@@ -83,12 +82,10 @@ def populate_config(
     CONFIG_VALUES["ssh_key"] = keyname
     CONFIG_VALUES["sbonexusdata_bucket"] = get_sbonexusdata_bucket()
     CONFIG_VALUES["containers_bucket"] = get_containers_bucket()
-    if dev:
-        CONFIG_VALUES["scratch_bucket"] = "/".join([get_scratch_bucket(), vlab_id, project_id])
-    elif benchmark:
+    if benchmark:
         CONFIG_VALUES["scratch_bucket"] = get_scratch_bucket()
     else:
-        CONFIG_VALUES["scratch_bucket"] = get_scratch_bucket()
+        CONFIG_VALUES["scratch_bucket"] = "/".join([get_scratch_bucket(), vlab_id, project_id])
     CONFIG_VALUES["efa_security_group_id"] = get_efa_security_group_id()
     if cluster_users:
         CONFIG_VALUES["cluster_users"] = cluster_users
@@ -194,13 +191,11 @@ def pcluster_create(
             }
         ]
     )
-    populate_config(
-        cluster_name, options["keyname"], vlab_id, project_id, cluster_users, dev, benchmark
-    )
+    populate_config(cluster_name, options["keyname"], vlab_id, project_id, cluster_users, benchmark)
     pcluster_config = load_pcluster_config(dev)
     pcluster_config["Tags"] = populate_tags(pcluster_config, vlab_id, project_id)
     pcluster_config["Scheduling"]["SlurmQueues"] = choose_tier(pcluster_config, options)
-    if options["include_lustre"].lower() != "true":
+    if not options["include_lustre"]:
         pcluster_config["SharedStorage"].pop(1)
     output_file_name = write_config(cluster_name, pcluster_config)
 

--- a/hpc_provisioner/src/hpc_provisioner/pcluster_manager.py
+++ b/hpc_provisioner/src/hpc_provisioner/pcluster_manager.py
@@ -63,6 +63,7 @@ def populate_config(
     project_id: str,
     cluster_users: Optional[str] = None,
     dev: Optional[bool] = False,
+    benchmark: Optional[bool] = False,
 ) -> None:
     """
     populate config values for loading cluster config yaml
@@ -84,6 +85,8 @@ def populate_config(
     CONFIG_VALUES["containers_bucket"] = get_containers_bucket()
     if dev:
         CONFIG_VALUES["scratch_bucket"] = "/".join([get_scratch_bucket(), vlab_id, project_id])
+    elif benchmark:
+        CONFIG_VALUES["scratch_bucket"] = get_scratch_bucket()
     else:
         CONFIG_VALUES["scratch_bucket"] = get_scratch_bucket()
     CONFIG_VALUES["efa_security_group_id"] = get_efa_security_group_id()
@@ -180,6 +183,7 @@ def pcluster_create(
         return
 
     dev = options["dev"]
+    benchmark = options["benchmark"]
     cluster_users = json.dumps(
         [
             {
@@ -190,7 +194,9 @@ def pcluster_create(
             }
         ]
     )
-    populate_config(cluster_name, options["keyname"], vlab_id, project_id, cluster_users, dev)
+    populate_config(
+        cluster_name, options["keyname"], vlab_id, project_id, cluster_users, dev, benchmark
+    )
     pcluster_config = load_pcluster_config(dev)
     pcluster_config["Tags"] = populate_tags(pcluster_config, vlab_id, project_id)
     pcluster_config["Scheduling"]["SlurmQueues"] = choose_tier(pcluster_config, options)

--- a/hpc_provisioner/src/hpc_provisioner/pcluster_manager.py
+++ b/hpc_provisioner/src/hpc_provisioner/pcluster_manager.py
@@ -56,7 +56,13 @@ class InvalidRequest(Exception):
     """When the request is invalid, likely due to invalid or missing data"""
 
 
-def populate_config(cluster_name: str, keyname: str, cluster_users: Optional[str] = None) -> None:
+def populate_config(
+    cluster_name: str,
+    keyname: str,
+    project_id: str,
+    cluster_users: Optional[str] = None,
+    dev: Optional[bool] = False,
+) -> None:
     """
     populate config values for loading cluster config yaml
 
@@ -75,7 +81,10 @@ def populate_config(cluster_name: str, keyname: str, cluster_users: Optional[str
     CONFIG_VALUES["ssh_key"] = keyname
     CONFIG_VALUES["sbonexusdata_bucket"] = get_sbonexusdata_bucket()
     CONFIG_VALUES["containers_bucket"] = get_containers_bucket()
-    CONFIG_VALUES["scratch_bucket"] = get_scratch_bucket()
+    if dev:
+        CONFIG_VALUES["scratch_bucket"] = "/".join([get_scratch_bucket(), project_id])
+    else:
+        CONFIG_VALUES["scratch_bucket"] = get_scratch_bucket()
     CONFIG_VALUES["efa_security_group_id"] = get_efa_security_group_id()
     if cluster_users:
         CONFIG_VALUES["cluster_users"] = cluster_users
@@ -180,7 +189,7 @@ def pcluster_create(
             }
         ]
     )
-    populate_config(cluster_name, options["keyname"], cluster_users)
+    populate_config(cluster_name, options["keyname"], project_id, cluster_users, dev)
     pcluster_config = load_pcluster_config(dev)
     pcluster_config["Tags"] = populate_tags(pcluster_config, vlab_id, project_id)
     pcluster_config["Scheduling"]["SlurmQueues"] = choose_tier(pcluster_config, options)

--- a/hpc_provisioner/src/hpc_provisioner/pcluster_manager.py
+++ b/hpc_provisioner/src/hpc_provisioner/pcluster_manager.py
@@ -170,7 +170,16 @@ def pcluster_create(
         return
 
     dev = options["dev"]
-    cluster_users = json.dumps([{"name": "sim", "public_key": options["sim_pubkey"]}])
+    cluster_users = json.dumps(
+        [
+            {
+                "name": "sim",
+                "public_key": options["sim_pubkey"],
+                "sudo": False,
+                "folder_ownership": ["/sbo/data/scratch"],
+            }
+        ]
+    )
     populate_config(cluster_name, options["keyname"], cluster_users)
     pcluster_config = load_pcluster_config(dev)
     pcluster_config["Tags"] = populate_tags(pcluster_config, vlab_id, project_id)

--- a/hpc_provisioner/src/hpc_provisioner/pcluster_manager.py
+++ b/hpc_provisioner/src/hpc_provisioner/pcluster_manager.py
@@ -16,6 +16,7 @@ from pcluster import lib as pc
 from pcluster.api.errors import CreateClusterBadRequestException, InternalServiceException
 
 from hpc_provisioner.aws_queries import (
+    create_bucket_path,
     get_available_subnet,
     get_cluster_name,
     get_efs,
@@ -190,6 +191,9 @@ def pcluster_create(
         ]
     )
     populate_config(cluster_name, options["keyname"], project_id, cluster_users, dev)
+    if dev:
+        s3_client = boto3.client("s3")
+        create_bucket_path(s3_client, get_scratch_bucket(), project_id)
     pcluster_config = load_pcluster_config(dev)
     pcluster_config["Tags"] = populate_tags(pcluster_config, vlab_id, project_id)
     pcluster_config["Scheduling"]["SlurmQueues"] = choose_tier(pcluster_config, options)

--- a/hpc_provisioner/src/hpc_provisioner/utils.py
+++ b/hpc_provisioner/src/hpc_provisioner/utils.py
@@ -3,20 +3,27 @@ import os
 from cryptography.hazmat.primitives import serialization
 
 
-def get_sbonexusdata_bucket():
-    return os.environ.get("SBO_NEXUSDATA_BUCKET")
+def _get_bucket_from_env(var_name: str) -> str:
+    if bucket := os.environ.get(var_name):
+        return bucket
+    else:
+        raise ValueError(f"{var_name} not set")
 
 
-def get_containers_bucket():
-    return os.environ.get("CONTAINERS_BUCKET")
+def get_sbonexusdata_bucket() -> str:
+    return _get_bucket_from_env("SBO_NEXUSDATA_BUCKET")
 
 
-def get_scratch_bucket():
-    return os.environ.get("SCRATCH_BUCKET")
+def get_containers_bucket() -> str:
+    return _get_bucket_from_env("CONTAINERS_BUCKET")
 
 
-def get_efa_security_group_id():
-    return os.environ.get("EFA_SG_ID")
+def get_scratch_bucket() -> str:
+    return _get_bucket_from_env("SCRATCH_BUCKET")
+
+
+def get_efa_security_group_id() -> str:
+    return _get_bucket_from_env("EFA_SG_ID")
 
 
 def generate_public_key(key_material):

--- a/hpc_provisioner/tests/test_resource_provisioner.py
+++ b/hpc_provisioner/tests/test_resource_provisioner.py
@@ -216,6 +216,7 @@ e15Cgo+/r/nqbT21oTkp4rbw5nT9lVyuHyBralzJ7Q/BDXXY0v0=
         "project_id": post_event["project_id"],
         "keyname": f"pcluster-{post_event['vlab_id']}-{post_event['project_id']}",
         "options": {
+            "benchmark": False,
             "dev": False,
             "include_lustre": None,
             "tier": None,

--- a/hpc_provisioner/tests/test_resource_provisioner.py
+++ b/hpc_provisioner/tests/test_resource_provisioner.py
@@ -218,7 +218,7 @@ e15Cgo+/r/nqbT21oTkp4rbw5nT9lVyuHyBralzJ7Q/BDXXY0v0=
         "options": {
             "benchmark": False,
             "dev": False,
-            "include_lustre": None,
+            "include_lustre": True,
             "tier": None,
             "project_id": post_event["project_id"],
             "vlab_id": post_event["vlab_id"],

--- a/provisioner_scripts/create_users.py
+++ b/provisioner_scripts/create_users.py
@@ -1,10 +1,15 @@
 #!/usr/bin/env python3
+import time
+import os
 
 from io import TextIOWrapper
 import json
 import subprocess
 import sys
 from typing import List, Optional, Union
+
+
+TIMEOUT = 900
 
 
 def run_cmd(
@@ -82,7 +87,15 @@ def create_user(
         f"chown -R {name}:{name} /home/{name}/.ssh",
         f"Set ownership for {name} .ssh dir",
     )
+    timeout = time.time() + TIMEOUT
     for folder in folder_ownership:
+        while not os.path.exists(folder) and time.time() < timeout:
+            print(f"Waiting for {folder} to appear")
+            time.sleep(10)
+        if not os.path.exists(folder):
+            raise RuntimeError(
+                f"Path {folder} did not appear within {TIMEOUT} seconds."
+            )
         run_cmd(
             f"chown -R {name}:{name} {folder}",
             f"Assign ownership of {folder} to {name}",

--- a/provisioner_scripts/create_users.py
+++ b/provisioner_scripts/create_users.py
@@ -4,7 +4,7 @@ from io import TextIOWrapper
 import json
 import subprocess
 import sys
-from typing import Union
+from typing import List, Optional, Union
 
 
 def run_cmd(
@@ -35,7 +35,12 @@ def run_cmd(
 
 
 # Helper method to create a user and configure sudo permissions
-def create_user(name: str, public_ssh_key: str, sudo: bool = False) -> None:
+def create_user(
+    name: str,
+    public_ssh_key: str,
+    sudo: bool = False,
+    folder_ownership: List[Optional[str]] = [],
+) -> None:
     """
     Create a user and configure sudo permissions, if necessary
 
@@ -77,6 +82,11 @@ def create_user(name: str, public_ssh_key: str, sudo: bool = False) -> None:
         f"chown -R {name}:{name} /home/{name}/.ssh",
         f"Set ownership for {name} .ssh dir",
     )
+    for folder in folder_ownership:
+        run_cmd(
+            f"chown -R {name}:{name} {folder}",
+            f"Assign ownership of {folder} to {name}",
+        )
 
 
 def main(argv):
@@ -98,7 +108,12 @@ def main(argv):
     print(f"Users: {users}")
     for user in users:
         print(f"Creating user {user}")
-        create_user(user["name"], user["public_key"], user.get("sudo", False))
+        create_user(
+            user["name"],
+            user["public_key"],
+            user.get("sudo", False),
+            user.get("folder_ownership", []),
+        )
 
 
 if __name__ == "__main__":

--- a/provisioner_scripts/create_users.py
+++ b/provisioner_scripts/create_users.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3
 import time
-import os
 
 from io import TextIOWrapper
 import json
@@ -88,18 +87,18 @@ def create_user(
         f"Set ownership for {name} .ssh dir",
     )
     timeout = time.time() + TIMEOUT
-    for folder in folder_ownership:
-        while not os.path.exists(folder) and time.time() < timeout:
-            print(f"Waiting for {folder} to appear")
-            time.sleep(10)
-        if not os.path.exists(folder):
-            raise RuntimeError(
-                f"Path {folder} did not appear within {TIMEOUT} seconds."
-            )
-        run_cmd(
-            f"chown -R {name}:{name} {folder}",
-            f"Assign ownership of {folder} to {name}",
-        )
+    # for folder in folder_ownership:
+    #     while not os.path.exists(folder) and time.time() < timeout:
+    #         print(f"Waiting for {folder} to appear")
+    #         time.sleep(10)
+    #     if not os.path.exists(folder):
+    #         raise RuntimeError(
+    #             f"Path {folder} did not appear within {TIMEOUT} seconds."
+    #         )
+    #     run_cmd(
+    #         f"chown -R {name}:{name} {folder}",
+    #         f"Assign ownership of {folder} to {name}",
+    #     )
 
 
 def main(argv):


### PR DESCRIPTION
- test fixes
- changes in /sbo/data/{project,containers} no longer exported to S3
- slurm queues cleanup suggested in previous PR
- new benchmark flag
- cleaner handling of boolean parameters
- unless benchmark is set, mount vlab/project-specific scratch dir instead of the whole bucket
- preparation to chown scratch to sim user (not active yet)
- die on unset environment variables

Lays some groundwork for #12
Fixes #17
